### PR TITLE
Fix cloudinary

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
J'ai changé la ligne suivante dans developement.rb :

config.active_storage.service = :cloudinary <- bonne version